### PR TITLE
Added: Support iOS 13 dark theme.

### DIFF
--- a/SwiftDataTables/Classes/Models/DataTableConfiguration.swift
+++ b/SwiftDataTables/Classes/Models/DataTableConfiguration.swift
@@ -9,6 +9,52 @@
 import Foundation
 import UIKit
 
+public enum DataStyles {
+    
+    public enum Colors {
+        
+        public static var highlightedFirstColor: UIColor = {
+            return setupColor(normalColor: UIColor(red: 0.941, green: 0.941, blue: 0.941, alpha: 1),
+                              darkColor: UIColor(red: 0.16, green: 0.16, blue: 0.16, alpha: 1),
+                              defaultColor: UIColor(red: 0.941, green: 0.941, blue: 0.941, alpha: 1))
+        }()
+        
+        public static var highlightedSecondColor: UIColor = {
+            return setupColor(normalColor: UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1),
+                              darkColor: UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 1),
+                              defaultColor: UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1))
+        }()
+        
+        public static var unhighlightedFirstColor: UIColor = {
+            return setupColor(normalColor: UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1),
+                              darkColor: UIColor(red: 0.06, green: 0.06, blue: 0.06, alpha: 1),
+                              defaultColor: UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1))
+        }()
+        
+        public static var unhighlightedSecondColor: UIColor = {
+            return setupColor(normalColor: .white,
+                              darkColor: UIColor(red: 0.03, green: 0.03, blue: 0.03, alpha: 1),
+                              defaultColor: .white)
+        }()
+    }
+}
+
+public let Style = DataStyles.self
+
+private func setupColor(normalColor: UIColor, darkColor: UIColor, defaultColor: UIColor) -> UIColor {
+    if #available(iOS 13, *) {
+        return UIColor.init { (trait) -> UIColor in
+            if trait.userInterfaceStyle == .dark {
+                return darkColor
+            } else {
+                return normalColor
+            }
+        }
+    } else {
+        return defaultColor
+    }
+}
+
 public struct DataTableColumnOrder: Equatable {
     //MARK: - Properties
     let index: Int
@@ -40,12 +86,12 @@ public struct DataTableConfiguration: Equatable {
     public var shouldSupportRightToLeftInterfaceDirection: Bool = true
     
     public var highlightedAlternatingRowColors = [
-        UIColor(red: 0.941, green: 0.941, blue: 0.941, alpha: 1),
-        UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1)
+        DataStyles.Colors.highlightedFirstColor,
+        DataStyles.Colors.highlightedSecondColor
     ]
     public var unhighlightedAlternatingRowColors = [
-        UIColor(red: 0.9725, green: 0.9725, blue: 0.9725, alpha: 1),
-        .white
+        DataStyles.Colors.unhighlightedFirstColor,
+        DataStyles.Colors.unhighlightedSecondColor
     ]
     
     public var fixedColumns: DataTableFixedColumnType? = nil

--- a/SwiftDataTables/Classes/SwiftDataTable.swift
+++ b/SwiftDataTables/Classes/SwiftDataTable.swift
@@ -58,8 +58,15 @@ public class SwiftDataTable: UIView {
         searchBar.searchBarStyle = .minimal;
         searchBar.placeholder = "Search";
         searchBar.delegate = self
-        searchBar.backgroundColor = .white
-        searchBar.barTintColor = UIColor.white
+        if #available(iOS 13.0, *) {
+            searchBar.backgroundColor = .systemBackground
+            searchBar.barTintColor = .label
+        } else {
+            searchBar.backgroundColor = .white
+            searchBar.barTintColor = .white
+        }
+        
+        
         self.addSubview(searchBar)
         return searchBar
     }()
@@ -70,7 +77,11 @@ public class SwiftDataTable: UIView {
             fatalError("The layout needs to be set first")
         }
         let collectionView = UICollectionView(frame: self.bounds, collectionViewLayout: layout)
-        collectionView.backgroundColor = UIColor.clear
+        if #available(iOS 13.0, *) {
+            collectionView.backgroundColor = UIColor.systemBackground
+        } else {
+            collectionView.backgroundColor = UIColor.clear
+        }
         collectionView.allowsMultipleSelection = true
         collectionView.dataSource = self
         collectionView.delegate = self
@@ -399,7 +410,11 @@ extension SwiftDataTable: UICollectionViewDataSource, UICollectionViewDelegate {
         case .paginationHeader:
             view.backgroundColor = UIColor.darkGray
         default:
-            view.backgroundColor = UIColor.white
+            if #available(iOS 13.0, *) {
+                view.backgroundColor = .systemBackground
+            } else {
+                view.backgroundColor = UIColor.white
+            }
         }
     }
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {


### PR DESCRIPTION
Added support iOS 13 dark mode. Without this edits, dark mode seems like very bad. 
In original version, footer, header, search bar and all collection cells background color still white when switch themes. I think this not all, some colors i don't changed (ex. case .paginationHeader in 411 line), but all seens like normal.