### PR TITLE
Improved column width calculation

### DIFF
--- a/SwiftDataTables/Classes/Cells/DataCell/DataCell.swift
+++ b/SwiftDataTables/Classes/Cells/DataCell/DataCell.swift
@@ -11,7 +11,7 @@ import UIKit
 class DataCell: UICollectionViewCell {
 
     //MARK: - Properties
-    private enum Properties {
+    public enum Properties {
         static let verticalMargin: CGFloat = 5
         static let horizontalMargin: CGFloat = 15
         static let widthConstant: CGFloat = 20

--- a/SwiftDataTables/Classes/Cells/HeaderFooter/DataHeaderFooter.swift
+++ b/SwiftDataTables/Classes/Cells/HeaderFooter/DataHeaderFooter.swift
@@ -47,7 +47,7 @@ class DataHeaderFooter: UICollectionReusableView {
     
     func setupViews() {
         titleLabel.adjustsFontSizeToFitWidth = true
-        titleLabel.font = UIFont.systemFont(ofSize: 17, weight: .heavy)
+        titleLabel.font = UIFont.systemFont(ofSize: UIFont.labelFontSize, weight: .heavy)
         addSubview(titleLabel)
         addSubview(sortingImageView)
         let tapGesture = UITapGestureRecognizer.init(target: self, action: #selector(DataHeaderFooter.didTapView))

--- a/SwiftDataTables/Classes/Extensions/SwiftDataTable+Extensions.swift
+++ b/SwiftDataTables/Classes/Extensions/SwiftDataTable+Extensions.swift
@@ -29,3 +29,11 @@ extension UIScrollView {
         self.contentOffset = CGPoint(x: -contentInset.left, y: -contentInset.top)
     }
 }
+
+extension String {
+  func widthOfString(usingFont font: UIFont) -> CGFloat {
+    let fontAttributes = [NSAttributedString.Key.font: font]
+    let size = self.size(withAttributes: fontAttributes)
+    return size.width
+  }
+}

--- a/SwiftDataTables/Classes/Models/DataStructureModel.swift
+++ b/SwiftDataTables/Classes/Models/DataStructureModel.swift
@@ -77,7 +77,7 @@ public struct DataStructureModel {
         for column in Array(0..<self.headerTitles.count) {
             let averageForCurrentColumn = Array(0..<data.count).reduce(0){
                 let dataType: DataTableValueType = data[$1][column]
-                return $0 + dataType.stringRepresentation.count
+              return $0 + Int(dataType.stringRepresentation.widthOfString(usingFont: UIFont.systemFont(ofSize: 17)).rounded(.up))
             }
             columnContentAverages.append((data.count == 0) ? 1 : Float(averageForCurrentColumn) / Float(data.count))
         }

--- a/SwiftDataTables/Classes/Models/DataStructureModel.swift
+++ b/SwiftDataTables/Classes/Models/DataStructureModel.swift
@@ -77,7 +77,7 @@ public struct DataStructureModel {
         for column in Array(0..<self.headerTitles.count) {
             let averageForCurrentColumn = Array(0..<data.count).reduce(0){
                 let dataType: DataTableValueType = data[$1][column]
-              return $0 + Int(dataType.stringRepresentation.widthOfString(usingFont: UIFont.systemFont(ofSize: 17)).rounded(.up))
+              return $0 + Int(dataType.stringRepresentation.widthOfString(usingFont: UIFont.systemFont(ofSize: UIFont.labelFontSize)).rounded(.up))
             }
             columnContentAverages.append((data.count == 0) ? 1 : Float(averageForCurrentColumn) / Float(data.count))
         }

--- a/SwiftDataTables/Classes/SwiftDataTable.swift
+++ b/SwiftDataTables/Classes/SwiftDataTable.swift
@@ -686,8 +686,8 @@ extension SwiftDataTable {
     /// - Returns: The automatic width of the column irrespective of the Data Grid frame width
     func automaticWidthForColumn(index: Int) -> CGFloat {
         let columnAverage: CGFloat = CGFloat(dataStructure.averageDataLengthForColumn(index: index))
-        let sortingArrowVisualElementWidth: CGFloat = 20 // This is ugly
-        let averageDataColumnWidth: CGFloat = columnAverage * self.pixelsPerCharacter() + sortingArrowVisualElementWidth
+        let sortingArrowVisualElementWidth: CGFloat = 10 // This is ugly
+      let averageDataColumnWidth: CGFloat = columnAverage + sortingArrowVisualElementWidth + (DataCell.Properties.horizontalMargin * 2)
         return max(averageDataColumnWidth, max(self.minimumColumnWidth(), self.minimumHeaderColumnWidth(index: index)))
     }
     
@@ -701,12 +701,7 @@ extension SwiftDataTable {
     }
     
     func minimumHeaderColumnWidth(index: Int) -> CGFloat {
-        return CGFloat(self.pixelsPerCharacter() * CGFloat(self.dataStructure.headerTitles[index].count))
-    }
-    
-    //There should be an automated way to retrieve the font size of the cell
-    func pixelsPerCharacter() -> CGFloat {
-        return 14
+      return CGFloat(self.dataStructure.headerTitles[index].widthOfString(usingFont: UIFont.boldSystemFont(ofSize: 17)))
     }
     
     func heightForPaginationView() -> CGFloat {

--- a/SwiftDataTables/Classes/SwiftDataTable.swift
+++ b/SwiftDataTables/Classes/SwiftDataTable.swift
@@ -701,7 +701,7 @@ extension SwiftDataTable {
     }
     
     func minimumHeaderColumnWidth(index: Int) -> CGFloat {
-      return CGFloat(self.dataStructure.headerTitles[index].widthOfString(usingFont: UIFont.boldSystemFont(ofSize: 17)))
+      return CGFloat(self.dataStructure.headerTitles[index].widthOfString(usingFont: UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)))
     }
     
     func heightForPaginationView() -> CGFloat {


### PR DESCRIPTION
Use actual width of strings when system font is applied instead of assuming 14 pixels per character

see #59 